### PR TITLE
Allow file/link extensions different than .html

### DIFF
--- a/urubu/processors.py
+++ b/urubu/processors.py
@@ -116,7 +116,7 @@ class ContentProcessor(object):
             html = templ.render(this=info, site=self.site)
             fn = info['fn']
             bfn, ext = os.path.splitext(fn)
-            outfn = os.path.join(self.sitedir, bfn) + '.html'
+            outfn = os.path.join(self.sitedir, bfn) + self.site['file_ext']
             with open(outfn, 'w', encoding='utf-8', errors='strict') as outf:
                outf.write(html)
         

--- a/urubu/project.py
+++ b/urubu/project.py
@@ -82,7 +82,9 @@ class Project(object):
     def __init__(self):
         self.config = {}
         self.site = {'brand' : '',
-                     'reflinks': {}
+                     'reflinks': {},
+                     'link_ext' : '.html',
+                     'file_ext' : '.html'
                     }
         self.fileinfo = []
         self.filerefs = {}
@@ -195,7 +197,7 @@ class Project(object):
         info['components'] = components = get_components(relfn)
         info['id'] = make_id(components)
         # make html url from ref 
-        info['url'] = info['id'] + '.html'
+        info['url'] = info['id'] + self.site['link_ext']
         info.update(meta)
         return info
 


### PR DESCRIPTION
Default functionality does not change, but there are now two new keys
available for the _site.yml file:
- link_ext: file extension to be added to the url links (instead of
  default .html)
- file_ext: file extension to be added to the processed .md files
  (instead of default .html)

Rationale:
In order to transparently replace a site that uses links without
extension ( i.e. www.test.com/account which actually accesses
account.html) it is necessary to keep links extension-less. For this
case (since .htaccess adds the .html to the requested urls) one uses
link_ext: '' and file_ext: '.html'.
However in other cases people may want to use the same for both (i.e.
'.htm' or '.php').
