### PR TITLE
Add ability to supply fragments to reference URLs.

### DIFF
--- a/doc/manual/authoring.md
+++ b/doc/manual/authoring.md
@@ -59,7 +59,11 @@ further on define it as follows:
 This is nice for readability, but it all remains file based.
 
 Urubu extends this behavior by automatically resolving project-wide reference
-links. (See the chapter about [structure]).
+links. (See the chapter about [structure]). In addition, you can add a
+fragment (e.g. #some-anchor) to the reference to link within a page. Since
+Urubu automatically adds slugified IDs to markdown headers, you can use those
+as targets. For instance, to link to this "Reference links" section of this
+page, you can use [authoring#reference-links][authoring#reference-links].
 
 This feature is implemented as a Markdown extension. Note that it doesn't
 require a syntax change. It enables page linking similar to what is commonly

--- a/urubu/md_extensions.py
+++ b/urubu/md_extensions.py
@@ -77,15 +77,20 @@ class ProjectReferencePattern(ReferencePattern):
                 id = id.lower()
             else:
                 id = ref
+            anchor = None
+            if '#' in id and id not in self.markdown.site['reflinks']:
+                id, anchor = id.split('#', 1)
             if ref in self.markdown.site['reflinks']:
                 if (ref != id) and (id in self.markdown.site['reflinks']):
-                    raise UrubuError(ambig_ref_error.format(ref, this['fn']))  
-                id = ref 
+                    raise UrubuError(ambig_ref_error.format(ref, this['fn']))
+                id = ref
             if id in self.markdown.site['reflinks']:
                 item = self.markdown.site['reflinks'][id]
-                href, title = item['url'], item['title'] 
+                href, title = item['url'], item['title']
                 if shortref:
                     text = title
+                if anchor is not None:
+                    href = '%s#%s' % (href, anchor)
             else: # ignore undefined refs
                 warn(undef_ref_warning.format(ref, this['fn']), UrubuWarning)
                 return None


### PR DESCRIPTION
Since Urubu automatically applies slugified IDs to headers, it
is nice to be able to link directly to a particular anchor within
a page. This change allows you to add a '#fragment' to the end
of a reference. For instance, `[/page#foo]` would generate the URL
`/page.html#foo`.