### PR TITLE
Add baseurl option to site configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,56 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/doc/_layouts/_base.html
+++ b/doc/_layouts/_base.html
@@ -15,8 +15,13 @@
     {%   set theme_path = "bootstrap/" + bootstrap + "/css" %}
     {% endif %}
     <link href="//netdna.bootstrapcdn.com/{{theme_path}}/bootstrap.min.css" rel="stylesheet" media="screen">
-    <link href="/css/site.css" rel="stylesheet" media="screen">
-    <link href="/css/syntax.css" rel="stylesheet" media="screen">
+
+    {% set url_prefix = '' %}
+    {% if site.baseurl %}
+    {%   set url_prefix = '/' + site.baseurl %}
+    {% endif %}
+    <link href="{{url_prefix + '/css/site.css'}}" rel="stylesheet" media="screen">
+    <link href="{{url_prefix + '/css/syntax.css'}}" rel="stylesheet" media="screen">
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
@@ -46,12 +51,12 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="/">{{site.brand}}</a>
+          <a class="navbar-brand" href="{{url_prefix + '/'}}">{{site.brand}}</a>
         </div>
         <div class="navbar-collapse collapse">
 
           <ul class="nav navbar-nav navbar-left">
-            {% block home %} 
+            {% block home %}
             {% endblock %}
             {% for item in site.reflinks['/'].content[:-navbar_right_items] %}
             {%   set context = '' %}
@@ -63,7 +68,7 @@
               <a href="{{item.url}}" class="dropdown-toggle" data-toggle="dropdown">{{item.title}} <b class="caret"></b></a>
               <ul class="dropdown-menu">
                 {% for subitem in item.content %}
-                <li><a href="{{subitem.url}}">{{subitem.title}}</a></li>    
+                <li><a href="{{subitem.url}}">{{subitem.title}}</a></li>
                 {% endfor %}
               </ul>
             </li>
@@ -84,7 +89,7 @@
               <a href="{{item.url}}" class="dropdown-toggle" data-toggle="dropdown">{{item.title}} <b class="caret"></b></a>
               <ul class="dropdown-menu">
                 {% for subitem in item.content %}
-                <li><a href="{{subitem.url}}">{{subitem.title}}</a></li>    
+                <li><a href="{{subitem.url}}">{{subitem.title}}</a></li>
                 {% endfor %}
               </ul>
             </li>

--- a/doc/_layouts/page.html
+++ b/doc/_layouts/page.html
@@ -6,7 +6,7 @@
 
   {% block breadcrumbs %}
   <ol class="breadcrumb">
-    <li><a href="/">Home</a></li>
+    <li><a href="{{url_prefix + '/'}}">Home</a></li>
       {% for bc in this.breadcrumbs[:-1] %}
       <li><a href="{{bc.url}}">{{bc.title}}</a></li>
       {% endfor %}
@@ -15,7 +15,7 @@
   {% endblock %}
 
   <div class="page-header">
-    {% block title %} 
+    {% block title %}
     <h1>{{this.title}}</h1>
     {% endblock %}
   </div>
@@ -23,8 +23,8 @@
   <div class="row">
 
     {% block sidebar %}
-    <div class="col-md-3" role="navigation"> 
-      {% if this.toc %} 
+    <div class="col-md-3" role="navigation">
+      {% if this.toc %}
       <div class="sidebar" data-spy="affix" data-offset-top="80" data-offset-bottom="60">
         <div class="well">
           <a href="#"><strong>{{this.title}}</strong></a>
@@ -34,7 +34,7 @@
       {% endif %}
     </div>
     {% endblock %}
- 
+
     <div class="content">
       {% block content %}
       <div class="col-md-6" role="main">
@@ -44,7 +44,7 @@
     </div>
 
   </div>
-    
+
   {% if this.pager %}
   <ul class="pager">
     {% if this.prev %}
@@ -58,7 +58,7 @@
 
   {% include 'footer.html' %}
 
-</div> 
+</div>
 
 {% endblock %}
 

--- a/urubu/project.py
+++ b/urubu/project.py
@@ -89,6 +89,7 @@ class Project(object):
     def __init__(self):
         self.config = {}
         self.site = {'brand': '',
+                     'baseurl': None,
                      'reflinks': {},
                      'link_ext': '.html',
                      'file_ext': '.html'
@@ -151,6 +152,12 @@ class Project(object):
         if id in self.site['reflinks']:
             raise UrubuError(ambig_reflink_error.format(id))
         self.site['reflinks'][id] = info
+
+    def finalize_local_url(self, url):
+        """Add a base to a local URL, if configured."""
+        if self.site['baseurl']:
+            url = '/' + self.site['baseurl'] + url
+        return url
 
     def get_contentinfo(self):
         """Get info from the markdown content files."""
@@ -233,7 +240,8 @@ class Project(object):
         info['components'] = components = get_components(relfn)
         info['id'] = make_id(components)
         # make html url from ref
-        info['url'] = info['id'] + self.site['link_ext']
+        info['url'] = self.finalize_local_url(
+            info['id'] + self.site['link_ext'])
         info.update(meta)
         return info
 
@@ -246,7 +254,7 @@ class Project(object):
         info['components'] = components = get_components(relpath)
         info['id'] = make_id(components)
         # add trailing slash for navigation url
-        info['url'] = info['id']
+        info['url'] = self.finalize_local_url(info['id'])
         if info['url'] != '/':
             info['url'] += '/'
         return info
@@ -368,7 +376,7 @@ class Project(object):
         info['components'] = components = (tagdir, tag)
         info['id'] = make_id(components)
         # add trailing slash for tag index url
-        info['url'] = info['id'] + '/'
+        info['url'] = self.finalize_local_url(info['id']) + '/'
         info['content'] = content
         return info
 


### PR DESCRIPTION
This is meant to mirror the baseurl option in Jekyll: http://jekyllrb.com/docs/configuration/#serve-command-options

It allows you to specify a prefix for all local URLs generated within your site. This is necessary when your site will be served from a URL that has more than just the hostname. For example, on GitHub Pages sites are served from http://username.github.io/project_name/, so Urubu needs to include that `/project_name/` in generated URLs pointing to local content.

The `baseurl` should be specified in `_site.yml` with no beginning or trailing slashes, e.g.:

```yaml
baseurl: prefix
```

I've confirmed that this doesn't break any existing functionality if `baseurl` is not set and that when `baseurl` is specified it correctly inserts the `baseurl` everywhere I checked. (I used my [tserv](https://gist.github.com/jiffyclub/043a44b524859a3cf70b) script to start a server listening with a prefix matching my `baseurl`.)