### PR TITLE
Add FAQ entry for previewing baseurl sites

### DIFF
--- a/doc/faq/baseurl-preview.md
+++ b/doc/faq/baseurl-preview.md
@@ -1,0 +1,20 @@
+---
+title: How to preview sites that use the baseurl option?
+layout: page
+date: 2015-04-30
+---
+
+The `urubu serve` server does not include the `baseurl` prefix when serving
+pages so sites that use `baseurl` can't be previewed locally using
+`urubu serve`.
+An alternative option is to use
+[tservice](https://github.com/jiffyclub/tservice), which includes
+an option to serve a local static site with a URL prefix.
+To use tservice with an Urubu site instead of using `urubu serve`
+call `tserve` with the prefix option, e.g.
+
+```
+tserve --prefix baseurl _build
+```
+
+Where "baseurl" is your site's particular prefix.


### PR DESCRIPTION
Links to my [tservice](https://github.com/jiffyclub/tservice) tool users can use to locally preview sites that use the `baseurl` prefix option.

(PR as requested in https://github.com/jandecaluwe/urubu/issues/7#issuecomment-78144829 .)