### PR TITLE
Add baseurl support to the serve() command

### DIFF
--- a/urubu/httphandler.py
+++ b/urubu/httphandler.py
@@ -25,14 +25,20 @@ class AliasingHTTPRequestHandler(httpserver.SimpleHTTPRequestHandler):
             httpserver.SimpleHTTPRequestHandler.do_GET(self)
             return
 
-        if self.path == "/":
-            # for convenience
+        wk_baseurl = "/%s/" % (baseurl)
+
+        if self.path[:len(wk_baseurl)] != wk_baseurl:
             self.send_response(302, 'Moved Temporarily')
-            self.send_header('Location', "/%s/" % (baseurl,))
+            sep = "/" if self.path[0] != "/" else ""
+
+            # note this replicates underlying bugs in that Location is
+            # not absolute as required by the spec and we throw away
+            # '?' and '#'
+
+            self.send_header('Location', "/%s%s%s" % (baseurl, sep, self.path))
             self.end_headers()
             return
         else:
-            wk_baseurl = "/%s/" % (baseurl)
             if self.path[:len(wk_baseurl)] == wk_baseurl:
                 self.path = self.path[len(wk_baseurl)-1:]
                 httpserver.SimpleHTTPRequestHandler.do_GET(self)

--- a/urubu/httphandler.py
+++ b/urubu/httphandler.py
@@ -1,0 +1,43 @@
+# Copyright 2015 Sreepathi Pai
+#
+# This file is part of Urubu.
+#
+# Urubu is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Urubu is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Urubu.  If not, see <http://www.gnu.org/licenses/>.
+
+from urubu._compat import httpserver
+
+class AliasingHTTPRequestHandler(httpserver.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        baseurl = self.server.baseurl
+
+        if not baseurl:
+            httpserver.SimpleHTTPRequestHandler.do_GET(self)
+            return
+
+        if self.path == "/":
+            # for convenience
+            self.send_response(302, 'Moved Temporarily')
+            self.send_header('Location', "/%s/" % (baseurl,))
+            self.end_headers()
+            return
+        else:
+            wk_baseurl = "/%s/" % (baseurl)
+            if self.path[:len(wk_baseurl)] == wk_baseurl:
+                self.path = self.path[len(wk_baseurl)-1:]
+                httpserver.SimpleHTTPRequestHandler.do_GET(self)
+            elif self.path == wk_baseurl[:-1]:
+                self.send_response(301, 'Moved Permanently')
+                self.send_header('Location', "/%s/" % (baseurl,))
+                self.end_headers()
+                return        

--- a/urubu/main.py
+++ b/urubu/main.py
@@ -25,8 +25,9 @@ from urubu import __version__
 from urubu import project
 
 from urubu._compat import socketserver, httpserver
+from urubu.httphandler import AliasingHTTPRequestHandler
 
-def serve():
+def serve(project):
     """HTTP server straight from the docs."""
     # allow running this from the top level
     if os.path.isdir('_build'):
@@ -34,9 +35,12 @@ def serve():
     # local use, address reuse should be OK
     socketserver.TCPServer.allow_reuse_address = True
     PORT = 8000
-    handler = httpserver.SimpleHTTPRequestHandler
+    handler = AliasingHTTPRequestHandler
     httpd = socketserver.TCPServer(('', PORT), handler)
+    httpd.baseurl = project.site['baseurl']
+        
     print("Serving at port {}".format(PORT))
+    if httpd.baseurl: print("Using baseurl {}".format(httpd.baseurl))
     httpd.serve_forever()
 
 def main():
@@ -47,4 +51,5 @@ def main():
     if args.command == 'build':
         project.build()
     elif args.command == 'serve':
-        serve()
+        proj = project.load()
+        serve(proj)

--- a/urubu/project.py
+++ b/urubu/project.py
@@ -451,11 +451,14 @@ class Project(object):
 
 # import pprint
 
-
-def build():
+def load():
     proj = Project()
     proj.get_config()
     proj.get_siteinfo()
+    return proj
+
+def build():
+    proj = load()
     proj.get_pythonhooks()
     proj.get_contentinfo()
     proj.resolve_reflinks()


### PR DESCRIPTION
This allows the website hosted by serve() to have the same base URLs as the final website. Many links are broken otherwise when used with a non-empty baseurl.