### PR TITLE
Use `select_template` to fetch templates

### DIFF
--- a/urubu/processors.py
+++ b/urubu/processors.py
@@ -78,11 +78,11 @@ class ContentProcessor(object):
         env.filters.update(project.filters)
         self.templates = {}
         for layout in project.layouts:
-            self.templates[layout] = self.env.get_template(layout + '.html')
+            self.templates[layout] = self.env.select_template([layout, layout + '.html'])
         # layout for tags is optional, triggers index file generation per tag
         try:
-            self.templates[tag_layout] = self.env.get_template(
-                tag_layout + '.html')
+            self.templates[tag_layout] = self.env.select_template(
+                [tag_layout, tag_layout + '.html'])
         except jinja2.exceptions.TemplateNotFound:
             if self.taglist:
                 warn(tag_layout_warning, UrubuWarning)


### PR DESCRIPTION
This allows users to have templates with file extensions other than
".html", but also stays compatible with the previous behaviour.

Quickly tested with the docs site, doesn't break anything.