### PR TITLE
Fix issues with markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 requires = ['jinja2 >= 2.7', 'pygments',
-            'markdown', 'pyyaml', 'beautifulsoup4']
+            'markdown >= 2.6', 'pyyaml', 'beautifulsoup4']
 
 entry_points = {
     'console_scripts': [


### PR DESCRIPTION
After installing with the default py-markdown port on FreeBSD (2.4.1) I ran into errors during startup.
```
$ urubu build
Traceback (most recent call last):
  File "/usr/local/bin/urubu", line 9, in <module>
    load_entry_point('urubu==1.2.0', 'console_scripts', 'urubu')()
  File "/usr/local/lib/python2.7/site-packages/urubu/main.py", line 52, in main
    project.build()
  File "/usr/local/lib/python2.7/site-packages/urubu/project.py", line 489, in build
    proj.make_site()
  File "/usr/local/lib/python2.7/site-packages/urubu/project.py", line 470, in make_site
    self.process_content()
  File "/usr/local/lib/python2.7/site-packages/urubu/project.py", line 475, in process_content
    p = processors.ContentProcessor(sitedir, project=self)
  File "/usr/local/lib/python2.7/site-packages/urubu/processors.py", line 74, in __init__
    extension_configs=extension_configs)
  File "/usr/local/lib/python2.7/site-packages/markdown/__init__.py", line 137, in __init__
    configs=kwargs.get('extension_configs', {}))
  File "/usr/local/lib/python2.7/site-packages/markdown/__init__.py", line 163, in registerExtensions
    ext = self.build_extension(ext, configs.get(ext, []))
  File "/usr/local/lib/python2.7/site-packages/markdown/__init__.py", line 211, in build_extension
    return module.makeExtension(configs.items())
  File "/usr/local/lib/python2.7/site-packages/markdown/extensions/toc.py", line 240, in makeExtension
    return TocExtension(configs=configs)
  File "/usr/local/lib/python2.7/site-packages/markdown/extensions/toc.py", line 226, in __init__
    self.setConfig(key, value)
  File "/usr/local/lib/python2.7/site-packages/markdown/extensions/__init__.py", line 36, in setConfig
    self.config[key][0] = value
KeyError: u'baselevel'
``` 
After updating the port to 2.6.5 it works as expected.

My conclusion was that urubu requires markdown >= 2.6