### PR TITLE
Add option for jinja2 to fail on undefined vars

### DIFF
--- a/doc/manual/structure.md
+++ b/doc/manual/structure.md
@@ -1,6 +1,6 @@
 ---
-title: Project structure 
-layout: page 
+title: Project structure
+layout: page
 pager: true
 author: Jan Decaluwe
 ---
@@ -34,7 +34,7 @@ folder2/index.md
 
 Files and directories with pathnames starting with an underscore `_` are
 special. They are used during processing, but excluded from the built website.
-Their function will be discussed below.  
+Their function will be discussed below.
 
 The `css` and `js` directories are just an example of how CSS style sheets and
 javascript files could be organized. You can use any organization that you
@@ -51,9 +51,9 @@ Urubu generates a website by processing the files and directory in the project
 directory, and putting the result in a `_build` subdirectory. The processing
 depends on the pathname as follows:
 
-* a `Makefile` is ignored and not copied to the build. 
+* a `Makefile` is ignored and not copied to the build.
 
-* files and directories starting with a dot `.` or 
+* files and directories starting with a dot `.` or
 underscore `_` are ignored and not copied to the build.
 
 * Markdown files with extension `.md` are converted to a
@@ -73,19 +73,21 @@ Special files and directories
 -----------
 
 This file contains site configuration info in YAML format.
-Currently, these are the predefined attributes: 
+Currently, these are the predefined attributes:
 
-Attribute         | Description
-------------------|-------------
-`reflinks`        | Holds a mapping from reference ids to link objects.
-`baseurl`         | Prefix for generated local URLs
-`file_ext`        | Change default file extension (`'.html'`) for processed `.md` files
-`link_ext`        | Change default file extension (`'.html'`) for links to site's pages
-`ignore_patterns` | List of additional file names or globs to be ignored during processing 
-`keep_files`      | List of explicit file names be kept, overriding any ignores 
+Attribute           | Description
+--------------------|-------------
+`reflinks`          | Holds a mapping from reference ids to link objects.
+`baseurl`           | Prefix for generated local URLs
+`file_ext`          | Change default file extension (`'.html'`) for processed `.md` files
+`link_ext`          | Change default file extension (`'.html'`) for links to site's pages
+`ignore_patterns`   | List of additional file names or globs to be ignored during processing
+`keep_files`        | List of explicit file names be kept, overriding any ignores
+`strict_undefined`  | Set the default behavior regarding undefined template variables
+
 
 Link objects, for the `reflinks` attribute, are a mapping with an `url` key that maps
-to the link URL and a `title` key that maps to the link title. 
+to the link URL and a `title` key that maps to the link title.
 
 The `baseurl` option mirrors the same feature in [Jekyll][jekyll-options].  It
 allows you to specify a prefix for all local URLs generated within your site.
@@ -112,23 +114,28 @@ be set to `''`, so that the `a href` links are directed to the files without ext
 
 Otherwise, `file_ext` and `link_ext` should be set to the same extension, specially
 during testing, so that the simple web server invoked by `urubu serve` works fine,
-as well as any web server that does not rewrite the file extensions of the requests. 
+as well as any web server that does not rewrite the file extensions of the requests.
 
 The `ignore_patterns` attribute specifies glob-style patterns to be ignored
 during processing, in addition to the default ones according to the
-[#Processing Rules]. 
+[#Processing Rules].
 
 In some cases you may explicitly want to keep certain files that would normally
 be ignored. For example, you may have hidden files like `.nojekyll` to prevent
 Jekyll processing, or `.htaccess` and `.htpasswd` for access control.  You can
 keep such files in the build using the `keep_files` attribute.
 
+The `strict_undefined` attribute controls whether the build should
+silently ignore undefined template variables or raise an error when they are
+encountered. If `false` or undefined, undefined template variables are treated
+as empty strings (`''`). If `true`, the build will stop and raise an error.
+
 You can define additional attributes that will be made available as
 site variables to the template engine. The following is an example of a
 `_site.yml` file:
 
 ```
-brand: Urubu 
+brand: Urubu
 
 reflinks:
     content_license:
@@ -138,9 +145,9 @@ reflinks:
         url: http://www.gnu.org/licenses/agpl-3.0.txt
         title: GNU Affero General Public License
     markdown:
-        url: http://daringfireball.net/projects/markdown/  
+        url: http://daringfireball.net/projects/markdown/
         title: Markdown
-        
+
 file_ext: '.htm'  # Change default file extension ('.html')
 link_ext: '.htm'  # Change default link extension ('.html')
 ```
@@ -154,9 +161,9 @@ The layout files should have the `.html` extension.
 
 `_python`
 ---------
-This directory contains Python hooks for the template engine. 
+This directory contains Python hooks for the template engine.
 
-Project-wide reference ids 
+Project-wide reference ids
 ==========================
 
 Urubu has the concept of project-wide reference ids.  You can use them to refer
@@ -169,12 +176,12 @@ configuration file, as discussed earlier.
 
 Project-wide references ids live in a single namespace. For pages and folders,
 the id is a root-relative pathname starting with a slash `/` and without file
-extension. By convention, global reference ids should not start with a `/`.   
+extension. By convention, global reference ids should not start with a `/`.
 
 In your content and configuration info, you can also use relative reference
 ids. Urubu will resolve them depending on the file location in the project. In
 case of a name clash with a global reference id, you will have to disambiguate
-by adding pathname components. 
+by adding pathname components.
 
 In accordance with Markdown conventions, reference ids are case-insensitive.
 
@@ -200,13 +207,13 @@ Attribute | Description
 `title`    | Specifies the page title. Mandatory.
 `layout`   | Specifies the layout, without the `.html` extension, or `null`. Mandatory.
 `date`     | Specifies the date in YYYY-MM-DD format. Optional.
-`tags`     | A tag or list of tags for the content. 
+`tags`     | A tag or list of tags for the content.
 
 The `layout` attribute is mandatory, but can be given a `null` value.
 This is useful when the page content is used by other pages, but
 no html output is required for the page itself.
 
-In addition, you can add arbitrary user-defined attributes. All attributes 
+In addition, you can add arbitrary user-defined attributes. All attributes
 are made available as page object attributes to the template engine.
 
 Markdown in attributes
@@ -214,20 +221,20 @@ Markdown in attributes
 
 Optionally, you can use markdown format in front matter attributes.  Markdown
 processing is enabled by adding a `.md` suffix to the attribute. The resulting
-html code will be stored in a synthesized attribute without the `.md` suffix.  
+html code will be stored in a synthesized attribute without the `.md` suffix.
 
 For example:
 
 ```
 ---
-title:  
+title:
 layout: page
 summary.md: |
     A summary of the page items as a list:
-    
+
     * item 1
     * item 2
-    * item 3 
+    * item 3
 ---
 ```
 
@@ -240,7 +247,7 @@ Index files
 Index files with basename `index.md` are a special kind of content files.  They
 are used to specify the attributes and the content of a directory. There are
 two options to specify the content, explicitly with the `content` attribute or
-implicitly using the `order` attribute.  
+implicitly using the `order` attribute.
 
 Attribute | Description
 -----------|------------
@@ -257,7 +264,7 @@ with a `title` key.
 The ordering attribute can be predefined or user-defined, but it should be
 specified in each content file in the directory.  As an example, you can
 specify that the content of a directory should be ordered as blog by the
-following front matter in the index file: 
+following front matter in the index file:
 
 ```
 ---

--- a/urubu/processors.py
+++ b/urubu/processors.py
@@ -62,7 +62,7 @@ class ContentProcessor(object):
         # there is a strange interaction between smarty and reference links that start on a new line
         # disabling smarty for now...
         # extensions = ['extra', 'codehilite', 'headerid', 'toc', 'smarty', tableclass, projectref]
-        extensions = ['extra', 'codehilite', 'toc', 
+        extensions = ['extra', 'codehilite', 'toc',
                       dlclass, tableclass, projectref, extractanchors]
         if self.site['mark_tag_support']:
             extensions.append(marktag)
@@ -73,11 +73,18 @@ class ContentProcessor(object):
         self.md = markdown.Markdown(extensions=extensions,
                                     extension_configs=extension_configs)
         self.md.site = self.site
-        self.md.anchors = project.anchors 
-        env = self.env = jinja2.Environment(loader=jinja2.FileSystemLoader(layoutdir),
-                                            lstrip_blocks=True,
-                                            trim_blocks=True
-                                            )
+        self.md.anchors = project.anchors
+        if 'strict_undefined' in self.site and self.site['strict_undefined']:
+            env = self.env = jinja2.Environment(
+                loader=jinja2.FileSystemLoader(layoutdir),
+                lstrip_blocks=True,
+                trim_blocks=True,
+                undefined=jinja2.StrictUndefined)
+        else:
+            env = self.env = jinja2.Environment(
+                loader=jinja2.FileSystemLoader(layoutdir),
+                lstrip_blocks=True,
+                trim_blocks=True)
         env.filters.update(project.filters)
         self.templates = {}
         for layout in project.layouts:
@@ -171,7 +178,7 @@ class ContentProcessor(object):
         if not os.path.isdir(tsd):
             return
         tsc = os.path.join(tsd, tipuesearch_content)
-        items = [] 
+        items = []
         # use tag index files if they have been rendered
         taglist = []
         if tag_layout in self.templates:
@@ -185,13 +192,13 @@ class ContentProcessor(object):
             item = {'text' : info['text'],
                     'title': info['title'],
                     'url'  : info['url'],
-                    'tags' : tags} 
+                    'tags' : tags}
             items.append(item)
         obj = {'pages': items}
         with open(tsc, 'w', encoding='utf-8') as fd:
             # json.dump is buggy in Python2 -- use workaround
-            # print json.dumps(obj, ensure_ascii=False, indent=4) 
-            data = json.dumps(obj, fd, ensure_ascii=False, indent=4, sort_keys=True) 
+            # print json.dumps(obj, ensure_ascii=False, indent=4)
+            data = json.dumps(obj, fd, ensure_ascii=False, indent=4, sort_keys=True)
             fd.write(text_type(data))
 
 

--- a/urubu/processors.py
+++ b/urubu/processors.py
@@ -75,16 +75,14 @@ class ContentProcessor(object):
         self.md.site = self.site
         self.md.anchors = project.anchors
         if 'strict_undefined' in self.site and self.site['strict_undefined']:
-            env = self.env = jinja2.Environment(
-                loader=jinja2.FileSystemLoader(layoutdir),
-                lstrip_blocks=True,
-                trim_blocks=True,
-                undefined=jinja2.StrictUndefined)
+            undefined_class = jinja2.StrictUndefined
         else:
-            env = self.env = jinja2.Environment(
-                loader=jinja2.FileSystemLoader(layoutdir),
-                lstrip_blocks=True,
-                trim_blocks=True)
+            undefined_class = jinja2.Undefined
+        env = self.env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(layoutdir),
+            lstrip_blocks=True,
+            trim_blocks=True,
+            undefined=undefined_class)
         env.filters.update(project.filters)
         self.templates = {}
         for layout in project.layouts:


### PR DESCRIPTION
If a variable is missing from a template, the current behavior of urubu is to treat it as an empty string. So if you forget to define (or define it wrong), the resulting HTML will be empty and you might not
realize it.

This adds an optional argument to `_site.yml` called `strict_undefined`. If omitted or `false`, urubu behaves normally. If defined and `true`, then will add `undefined=jinja2.StrictUndefined` to `jinja2.Environment` and jinja will fail with an error when an undefined variable is encountered.

I haven't added this to the docs. If you think it's a good option to have, then I'd welcome some pointers as to where I should document this.