### PR TITLE
main.py: Make serving on localhost the default

### DIFF
--- a/urubu/main.py
+++ b/urubu/main.py
@@ -27,29 +27,31 @@ from urubu import project
 from urubu._compat import socketserver, httpserver
 from urubu.httphandler import AliasingHTTPRequestHandler
 
-def serve(baseurl):
+def serve(baseurl, host='localhost', port=8000):
     """HTTP server straight from the docs."""
     # allow running this from the top level
     if os.path.isdir('_build'):
         os.chdir('_build')
     # local use, address reuse should be OK
     socketserver.TCPServer.allow_reuse_address = True
-    PORT = 8000
     handler = AliasingHTTPRequestHandler
-    httpd = socketserver.TCPServer(('', PORT), handler)
+    httpd = socketserver.TCPServer((host, port), handler)
     httpd.baseurl = baseurl
-        
-    print("Serving at port {}".format(PORT))
+
+    print("Serving {} at port {}".format(host, port))
     if httpd.baseurl: print("Using baseurl {}".format(httpd.baseurl))
     httpd.serve_forever()
 
 def main():
     parser = argparse.ArgumentParser(prog='python -m urubu')
     parser.add_argument('--version', action='version', version=__version__)
-    parser.add_argument('command', choices=['build', 'serve'])
+    parser.add_argument('command', choices=['build', 'serve', 'serveany'])
     args = parser.parse_args()
     if args.command == 'build':
         project.build()
     elif args.command == 'serve':
         proj = project.load()
         serve(proj.site['baseurl'])
+    elif args.command == 'serveany':
+        proj = project.load()
+        serve(proj.site['baseurl'], host='')


### PR DESCRIPTION
This also adds a new command, serveany, which acts just like the old code.
Safer defaults while not removing old functionality.

On OSX 10.10.5, the following will pop up with any connection using INADDR_ANY while the program is no explicitly authorized to do so. It does not pop-up when serving to localhost or loopback addresses.

![screen shot 2016-05-06 at 14 52 22](https://cloud.githubusercontent.com/assets/149972/15087055/5c13ff1e-139a-11e6-86d6-f3412a420a06.png)

Tested by running `python -m urubu serve` and `python -m urubu serveany` from the urubu-quickstart checkout and navigating the site.
