### PR TITLE
Fix crash under Python 3.

### DIFF
--- a/urubu/processors.py
+++ b/urubu/processors.py
@@ -202,7 +202,5 @@ class ContentProcessor(object):
         with open(tsc, 'w', encoding='utf-8') as fd:
             # json.dump is buggy in Python2 -- use workaround
             # print json.dumps(obj, ensure_ascii=False, indent=4)
-            data = json.dumps(obj, fd, ensure_ascii=False, indent=4, sort_keys=True)
+            data = json.dumps(obj, ensure_ascii=False, indent=4, sort_keys=True)
             fd.write(text_type(data))
-
-


### PR DESCRIPTION
Python 3's json.dumps doesn't accept extra positional argument.