### PR TITLE
Better interactive documentation

### DIFF
--- a/urubu/main.py
+++ b/urubu/main.py
@@ -27,6 +27,14 @@ from urubu import project
 from urubu._compat import socketserver, httpserver
 from urubu.httphandler import AliasingHTTPRequestHandler
 
+__IDESC__ = """
+Micro CMS tool to build and test static websites.
+"""
+
+__IEPILOG__ = """
+Documentation: <https://urubu.jandecaluwe.com/manual/>
+"""
+
 def serve(baseurl, host='localhost', port=8000):
     """HTTP server straight from the docs."""
     # allow running this from the top level
@@ -43,7 +51,8 @@ def serve(baseurl, host='localhost', port=8000):
     httpd.serve_forever()
 
 def main():
-    parser = argparse.ArgumentParser(prog='python -m urubu', add_help=False)
+    parser = argparse.ArgumentParser(prog='python -m urubu', add_help=False,
+                                     epilog=__IEPILOG__, description=__IDESC__)
     parser.add_argument('-h', '--help', action='help', help="show program's help and exit")
     parser.add_argument('-v', '--version', action='version', version=__version__)
     parser.add_argument('command', choices=['build', 'serve', 'serveany'])

--- a/urubu/main.py
+++ b/urubu/main.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import argparse
 
 import os
+from sys import stderr
 
 from urubu import __version__
 from urubu import project
@@ -46,7 +47,13 @@ def serve(baseurl, host='localhost', port=8000):
     httpd = socketserver.TCPServer((host, port), handler)
     httpd.baseurl = baseurl
 
-    print("Serving {} at port {}".format(host, port))
+    if host == '':
+        print("This web server is not safe for public/production use.", file=stderr)
+        print("Serving all peers at port {port}...\n\
+Browse <http://localhost:{port}/> (*:{port})".format(host=host, port=port))
+    else:
+        print("Serving {host} at port {port}...\n\
+Browse <http://{host}:{port}/>.".format(host=host, port=port))
     if httpd.baseurl: print("Using baseurl {}".format(httpd.baseurl))
     httpd.serve_forever()
 

--- a/urubu/main.py
+++ b/urubu/main.py
@@ -43,8 +43,9 @@ def serve(baseurl, host='localhost', port=8000):
     httpd.serve_forever()
 
 def main():
-    parser = argparse.ArgumentParser(prog='python -m urubu')
-    parser.add_argument('--version', action='version', version=__version__)
+    parser = argparse.ArgumentParser(prog='python -m urubu', add_help=False)
+    parser.add_argument('-h', '--help', action='help', help="show program's help and exit")
+    parser.add_argument('-v', '--version', action='version', version=__version__)
     parser.add_argument('command', choices=['build', 'serve', 'serveany'])
     args = parser.parse_args()
     if args.command == 'build':


### PR DESCRIPTION
Urubu now:

- Accepts the standard GNU-style syntaxes for the CLI arguments `version` and `help`;
- Shows a link to the official [manual](https://urubu.jandecaluwe.com/manual/) and a brief description of the tool itself;
- Makes sure the user understands what it is being done by `serve` and `serveany`.

The purpose of these commits is to flatten the learning curve a bit.