### PR TITLE
Fix ImportError for markdown.inlinepatterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Urubu 1.3.1
 Urubu is a micro CMS for static websites, with a focus on good navigation
 practices.
 
-All info can be found on the website: http://urubu.jandecaluwe.com
+All info can be found on the website: https://urubu.jandecaluwe.com

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 requires = ['jinja2 >= 2.10', 'pygments',
-            'markdown', 'pyyaml', 'beautifulsoup4']
+            'markdown < 3.0', 'pyyaml', 'beautifulsoup4']
 
 entry_points = {
     'console_scripts': [

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py36
 [testenv]
 changedir=urubu/tests
 deps=
-    markdown
+    markdown < 3.0
     pytest
     sh
     beautifulsoup4


### PR DESCRIPTION
Fixes:
`ImportError: cannot import name 'ReferencePattern' from 'markdown.inlinepatterns'`
...which happens when `Markdown` **>** `2.6.11` is automatically installed.
In addition, ensures the project home page is visited only via HTTPS.