### PR TITLE
Fix Tipue Search generator & documentation

### DIFF
--- a/doc/manual/search.md
+++ b/doc/manual/search.md
@@ -24,17 +24,13 @@ the integration is accomplished.
 Installing Tipue Search
 =======================
 
-The first step is to [download][1] the Tipue Search distribution It contains a
+The first step is to [download][1] the Tipue Search distribution. It contains a
 `tipuesearch` directory. Copy that directory to the top level of your project.
 As usual, Urubu copies it to the built website, so that the required
 stylesheets and javascript files are available in the expected location.
 
 Do not rename the `tipuesearch` directory. The existence of that
 directory triggers Urubu's support. 
-
-Tipue Search has good [documentation][2] that you may want to review.  This
-chapter uses a slightly modified approach to achieve a good integration in a
-typical Urubu project. 
 
 The search box
 ==============
@@ -146,5 +142,4 @@ use the `html5shiv.js` Javascript module. Layouts based on Bootstrap do
 this already.
 {.text-info}
 
-[1]: http://www.tipue.com/search/
-[2]: http://www.tipue.com/search/docs/
+[1]: https://github.com/calfzhou/Tipue-Search

--- a/urubu/processors.py
+++ b/urubu/processors.py
@@ -189,7 +189,7 @@ class ContentProcessor(object):
            taglist = self.taglist
         for info in itertools.chain(self.filelist, taglist):
             if 'text' not in info:
-                return
+                continue
             tags = ""
             if 'tags' in info:
                tags = ' '.join(info['tags'])
@@ -198,6 +198,8 @@ class ContentProcessor(object):
                     'url'  : info['url'],
                     'tags' : tags}
             items.append(item)
+        if len(items) <= 0:
+            return
         obj = {'pages': items}
         with open(tsc, 'w', encoding='utf-8') as fd:
             # json.dump is buggy in Python2 -- use workaround


### PR DESCRIPTION
- [Fix generation of tipuesearch_content.json when partial pages are present](https://github.com/jandecaluwe/urubu/commit/20c92fc718081efe0c31460fab9ab45632f6f776) (without this patch `tipuesearch_content.json` may silently disappear from build dir);
- [Replace hijacked internet domain with original GitHub repository in documentation](https://github.com/jandecaluwe/urubu/commit/d03e6760fdcdfe0850f88ec30a5d5c26f797e067) (it was leading to sex-related/music-related/&hellip; web pages).