### PR TITLE
Fix Dependency on Markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 requires = ['jinja2 >= 2.10', 'pygments',
-            'markdown < 3.0', 'pyyaml', 'beautifulsoup4']
+            'markdown >= 3.2', 'pyyaml', 'beautifulsoup4']
 
 entry_points = {
     'console_scripts': [

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py310
 [testenv]
 changedir=urubu/tests
 deps=
-    markdown < 3.0
+    markdown>=3.2
     pytest
     sh
     beautifulsoup4


### PR DESCRIPTION
In 1.3 urubu was not compatible with markdown >= 3.0, but now it is not compatible with version < 3.2.

1.4.0 depends e.g. on `ReferenceInlineProcessor` in `markdown/inlinepatterns.py`.